### PR TITLE
opendbc: Volvo CMA smoother steering (ported onto cschmittiey/opendbc)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "opendbc"]
   path = opendbc_repo
   url = ../../cschmittiey/opendbc.git
-  branch = volvo/safety-tests
+  branch = volvo/cma-steering
 [submodule "msgq"]
   path = msgq_repo
   url = ../../commaai/msgq.git


### PR DESCRIPTION
## Summary

Brings in Paper's (`paper5590`) Volvo/Polestar CMA **smoother-steering** work — but **ported onto your own opendbc** rather than swapping to Paper's opendbc lineage.

Bumps `opendbc_repo` to **`30677f2a`** on **`cschmittiey/opendbc` branch `volvo/cma-steering`** = your `opendbc main` (873e3d85) + Paper's LCA torque-authority envelope on top (3 Volvo files, **+184 / −3**).

## Why ported, not a straight submodule swap

The first attempt (pointing the submodule at Paper's `122da077`) broke the build:
```
ImportError: cannot import name 'get_generated_dbcs' from 'opendbc'   (SConstruct → tools/jotpluggler/SConscript)
```
Your openpilot base is **newer** than Paper's opendbc (which was rebased onto v0.11.0) and needs `get_generated_dbcs` → `generate_all`, absent in Paper's lineage. Rather than back-porting missing APIs into an older opendbc (whack-a-mole, older car-interface base), the ~130 lines of actual steering logic were ported **forward** onto your current opendbc, which keeps every other interface intact.

The two Volvo implementations were structurally aligned (same LCA 0x58 scheme, identical `create_lca_message`/`LCA_STEER_LOOSELY` signals), so the envelope logic is **byte-identical** to Paper's `122da077`. Only the integration differs: your carcontroller already clamps commanded angle via `ANGLE_ERROR`, so Paper's separate `MAX_ERR_DEG` clamp was intentionally **not** re-applied (avoids double-clamping).

## What the steering work does
A persistent LCA torque-authority envelope modeling stock Pilot Assist's easy-override feel:
- both authority arms held at saturation (±614) with no driver torque
- on override, symmetric collapse then asymmetric split (yield arm shallower than counter arm), scaled by driver-torque magnitude
- brief-yield haptic-ack on light contact (RSI-friendly), gated by a cooldown so it doesn't re-fire during active co-steering
- override-threshold **hysteresis** + LP-filtered driver torque → removes the ~10 Hz co-steering EPS-torque ripple
- slow (~2.7 s) rebuild to saturation after release

## ⚠️ Required before this resolves / installs
Commit `30677f2a` must be pushed into **`cschmittiey/opendbc`** as branch **`volvo/cma-steering`** (parent = your `main` 873e3d85). I don't have write access to opendbc from this session; that push is being done in a separate session. Until then the submodule won't resolve and CI stays red.

## ⚠️ Validation
Mechanical port verified: compiles, all `LCA_AUTH_*` constants defined, no new lint, logic byte-identical to Paper's. **Not** validated on-car — this is steering behavior and should be road-tested before relying on it.
